### PR TITLE
Introduced enum class GameState to replace defines

### DIFF
--- a/back2jungle/back2jungle.ino
+++ b/back2jungle/back2jungle.ino
@@ -16,8 +16,22 @@
 Arduboy2 arduboy;
 ArduboyPlaytune tunes(arduboy.audio.enabled);
 
-const byte MAINMENU = 255, SPLASH = 2, INTRO = 254, SKIPINTRO = 247, GAMEOVER = 253, END = 252, WIN = 251, LOSE = 250,
-           STARTLEVEL = 249, STARTLEVELINTRO = 248, PLAYING = 1;
+enum class GameState : unsigned char
+{
+  None,
+  Playing,
+  Splash,
+  SkipIntro,
+  StartLevelIntro,
+  StartLevel,
+  Lose,
+  Win,
+  End,
+  GameOver,
+  Intro,
+  MainMenu,
+};
+
 const int INVALID = -32768, EEPROM_START = EEPROM_STORAGE_SPACE_START + 100;
 
 // ------ Game parameters -------
@@ -28,7 +42,8 @@ int FORWARD_BOOST = 12; // Use higher value to make the player jump further.
 char lives = STARTLIVES;
 
 unsigned long currentFrame = 0, currentLevelTime = 0;
-byte currentLevel = STARTINGLEVEL, gameState = SPLASH;
+byte currentLevel = STARTINGLEVEL;
+GameState gameState = GameState::Splash;
 unsigned long wait = 0, debounce = 0;
 int score = 0, highscore = 0;
 char specialCar;

--- a/back2jungle/dialog.ino
+++ b/back2jungle/dialog.ino
@@ -93,9 +93,9 @@ void animateDialog(const unsigned char animal[], const unsigned char str[], bool
 
       default:
         arduboy.print(c);
-        tunes.tone(900, doDelays ? 20 : ((fasterDialogs && gameState != MAINMENU) ? 1 : 10));
+        tunes.tone(900, doDelays ? 20 : ((fasterDialogs && gameState != GameState::MainMenu) ? 1 : 10));
         arduboy.display();
-        arduboy.delayShort(doDelays ? 100 : ((fasterDialogs && gameState != MAINMENU) ? 1 : 12));
+        arduboy.delayShort(doDelays ? 100 : ((fasterDialogs && gameState != GameState::MainMenu) ? 1 : 12));
         break;
     }
 
@@ -108,7 +108,7 @@ void animateDialog(const unsigned char animal[], const unsigned char str[], bool
 #endif
 
   arduboy.display();
-  arduboy.delayShort(doDelays ? 1500 : ((fasterDialogs && gameState != MAINMENU) ? 10 : 300));
+  arduboy.delayShort(doDelays ? 1500 : ((fasterDialogs && gameState != GameState::MainMenu) ? 10 : 300));
 
   while (arduboy.pressed(B_BUTTON));
 }

--- a/back2jungle/events.ino
+++ b/back2jungle/events.ino
@@ -88,7 +88,7 @@ void doSplash()
   arduboy.print("presents");
   arduboy.display();
   arduboy.delayShort(2000);
-  gameState = MAINMENU;
+  gameState = GameState::MainMenu;
 }
 
 // Starts the menu music

--- a/back2jungle/game.ino
+++ b/back2jungle/game.ino
@@ -1,7 +1,7 @@
 // Main game loop, use interactive false for the level intro
-int doGame(bool interactive)
+GameState doGame(bool interactive)
 {
-  byte exitCode = !interactive ? STARTLEVELINTRO : ( playerx > arduboy.width() - 3 ? WIN : PLAYING);
+  GameState exitCode = !interactive ? GameState::StartLevelIntro : ( playerx > arduboy.width() - 3 ? GameState::Win : GameState::Playing);
   arduboy.clear();
 
   // Streets
@@ -46,7 +46,7 @@ int doGame(bool interactive)
     {
       // Pause game
       doPause();
-      return 1;
+      return GameState::Playing;
     }
 
     int multiplier = 1;
@@ -140,7 +140,7 @@ int doGame(bool interactive)
       {enemies[e].x + 2, (byte)(enemiesPos[enemy] + 2), (byte)(specs.width - 4), (byte)(specs.height - 4)}))
       {
         doCrash();
-        exitCode = LOSE;
+        exitCode = GameState::Lose;
       }
     }
     enemy++;
@@ -254,5 +254,5 @@ void doMainMenu()
   tunes.tone(987, 120);
   arduboy.delayShort(60);
   tunes.tone(1318, 400);
-  gameState = INTRO;
+  gameState = GameState::Intro;
 }

--- a/back2jungle/loop.ino
+++ b/back2jungle/loop.ino
@@ -5,27 +5,27 @@ void loop()
 
   switch (gameState)
   {
-    case SPLASH:
+    case GameState::Splash:
       doIntroTheme();
       doSplash();
 
-    case MAINMENU:
+    case GameState::MainMenu:
       doIntroTheme();
       doMainMenu();
       break;
 
-    case INTRO:
+    case GameState::Intro:
       doIntro();
 
-    case SKIPINTRO:
+    case GameState::SkipIntro:
       specialCarBonus = false;
       score = 0;
       currentLevel = 0;
       lives = STARTLIVES;
-      gameState = STARTLEVEL;
+      gameState = GameState::StartLevel;
       break;
 
-    case END:
+    case GameState::End:
       if (!tunes.playing())
         tunes.playScore(gameovertheme);
 
@@ -61,10 +61,10 @@ void loop()
         do
         {
           if ( waitForButton(false))
-            gameState = MAINMENU;
+            gameState = GameState::MainMenu;
           else if ( waitForButton(false, true, arduboy.height()))
-            gameState = SKIPINTRO;
-        } while (gameState == END);
+            gameState = GameState::SkipIntro;
+        } while (gameState == GameState::End);
 
         while (!arduboy.notPressed(A_BUTTON+B_BUTTON)); // Wait for button release
         tunes.stopScore();
@@ -73,18 +73,18 @@ void loop()
 
       break;
 
-    case WIN:
+    case GameState::Win:
       doWinDialog();
-      gameState = STARTLEVEL;
+      gameState = GameState::StartLevel;
       break;
 
-    case GAMEOVER:
-    case LOSE:
+    case GameState::GameOver:
+    case GameState::Lose:
       if (--lives <= 0)
       {
         animateDialog(monkeybig, gameover2);
         arduboy.delayShort(1000);
-        gameState = END;
+        gameState = GameState::End;
         wait =  millis() + (arduboy.audio.enabled() ? 2000 : 0);
         debounce = wait + 2000;
       }
@@ -92,11 +92,11 @@ void loop()
       {
         animateDialog(monkeybig, gameover1, true);
         waitForButton();
-        gameState = STARTLEVEL;
+        gameState = GameState::StartLevel;
       }
       break;
 
-    case STARTLEVEL:
+    case GameState::StartLevel:
       for (byte i = 0; i < enemiesMax; i++)
         enemiesPos[i] = arduboy.height();
 
@@ -106,21 +106,21 @@ void loop()
       currentFrame = 0;
       specialCar = -1;
 
-    case STARTLEVELINTRO:
+    case GameState::StartLevelIntro:
       if (playerx != INVALID)
         playerx += 0.15;
 
       if (playerx > 3)
       {
-        gameState = PLAYING;
+        gameState = GameState::Playing;
         currentLevelTime = millis();
       }
 
     default: // Level
-      if (!tunes.playing() && gameState == PLAYING)
+      if (!tunes.playing() && gameState == GameState::Playing)
         tunes.playScore(level);
 
-      gameState = doGame(gameState == PLAYING);
+      gameState = doGame(gameState == GameState::Playing);
 
 #ifdef DEBUG
       Serial.print("PLAYING, NEXT STATE: ");


### PR DESCRIPTION
While not strictly the same because I changed the values and made GameState equivalent to an unsigned char, this approach has several advantages:
- Implicit type-safety
- The actual values behind the names no longer matter to the programmer
- Any additional states can be added without having to designate values to them
- Added meaning to values (`return 1;` is no longer valid, the value is forced to be unambiguous)

Some of the space saving is from using `unsigned char` as the backing type (`unsigned char` actually results in less space usage than `char` because `char` is signed and signed numbers involve more work even when you aren't doing any arithmetic).
The rest of the space saving is the fact the values are now linear instead of jumping from 2 to 247. This allows the compiler to optimise the jumps used in the switch statement.